### PR TITLE
feat: implement signup markup

### DIFF
--- a/api/signup/index.ts
+++ b/api/signup/index.ts
@@ -1,0 +1,30 @@
+import axios from "axios";
+import { User } from "@type/User";
+
+const signupInfo = ({ id, password, nickname }: User): FormData => {
+  const formData = new FormData();
+  formData.append("id", id);
+  formData.append("password", password);
+  formData.append("nickname", nickname);
+
+  return formData;
+};
+
+export const submitSignupInfo = async (
+  id: string,
+  password: string,
+  nickname: string
+): Promise<User> => {
+  const response = await axios.post(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/signup`,
+    signupInfo({ id, password, nickname }),
+    {
+      withCredentials: true,
+    }
+  );
+
+  if (response.status !== 200) {
+    throw new Error("failted to submit signup info");
+  }
+  return response.data;
+};

--- a/api/signup/index.ts
+++ b/api/signup/index.ts
@@ -1,11 +1,12 @@
 import axios from "axios";
 import { User } from "@type/User";
 
-const signupInfo = ({ id, password, nickname }: User): FormData => {
+const signupInfo = ({ id, password, nickname /*image*/ }: User): FormData => {
   const formData = new FormData();
   formData.append("id", id);
   formData.append("password", password);
   formData.append("nickname", nickname);
+  // formData.append("image", image);
 
   return formData;
 };
@@ -13,11 +14,12 @@ const signupInfo = ({ id, password, nickname }: User): FormData => {
 export const submitSignupInfo = async (
   id: string,
   password: string,
-  nickname: string
+  nickname: string,
+  image?: string
 ): Promise<User> => {
   const response = await axios.post(
     `${process.env.NEXT_PUBLIC_API_URL}/api/signup`,
-    signupInfo({ id, password, nickname }),
+    signupInfo({ id, password, nickname /*image*/ }),
     {
       withCredentials: true,
     }

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -1,0 +1,113 @@
+import { useRouter } from "next/router";
+import React, { useEffect, useState } from "react";
+import Image from "next/image";
+import chiliEmoji from "@public/chili.svg";
+import {
+  Button,
+  Input,
+  Label,
+  Title,
+  Error,
+  Wrapper,
+  FormWrapper,
+} from "@styles/commonStyles";
+import { submitSignupInfo } from "@api/signup";
+import { checkPassword } from "@utils/checkPassword";
+
+const SignupPage = () => {
+  const router = useRouter();
+  const [id, setId] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
+  const [nickname, setNickname] = useState<string>("");
+  const [isIdValid, setIsIdValid] = useState<boolean>(true);
+  const [isPasswordValid, setIsPasswordValid] = useState<boolean>(true);
+  const [isNicknameValid, setIsNicknameValid] = useState<boolean>(true);
+  const [isIdErrorShown, setIsIdErrorShown] = useState<boolean>(false);
+  const [isPasswordErrorShown, setIsPasswordErrorShown] =
+    useState<boolean>(false);
+  const [isNicknameErrorShown, setIsNicknameErrorShown] =
+    useState<boolean>(false);
+
+  const changeIdValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setId(e.target.value);
+  };
+
+  const changePasswordValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+  };
+
+  const changeNicknameValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+  };
+
+  useEffect(() => {
+    setIsIdValid(id.length >= 5);
+    setIsPasswordValid(checkPassword(password));
+    setIsNicknameValid(nickname.length >= 2);
+  }, [id, password, nickname]);
+
+  const handleSubmit = async () => {
+    if (isIdValid && isPasswordValid && isNicknameValid) {
+      setIsIdErrorShown(false);
+      setIsPasswordErrorShown(false);
+      setIsNicknameErrorShown(false);
+      try {
+        await submitSignupInfo(id, password, nickname);
+        alert("생성되었습니다!");
+        router.push(`/login`);
+      } catch {}
+    } else {
+      setIsIdErrorShown(!isIdValid);
+      setIsPasswordErrorShown(!isPasswordValid);
+      setIsNicknameErrorShown(!isNicknameValid);
+    }
+  };
+
+  return (
+    <>
+      <Wrapper>
+        <Title>회원가입</Title>
+      </Wrapper>
+      <Wrapper>
+        <Image src={chiliEmoji} alt="chili" width={120} height={120} />
+        <Title>Welcome!</Title>
+      </Wrapper>
+      <FormWrapper>
+        <Label htmlFor="id">
+          <span>ID:</span>
+          <Input id="id" type="text" value={id} onChange={changeIdValue} />
+        </Label>
+        {isIdErrorShown && <Error>ID는 5글자 이상이어야 합니다.</Error>}
+        <Label htmlFor="password">
+          <span>PW:</span>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={changePasswordValue}
+          />
+        </Label>
+        {isPasswordErrorShown && (
+          <Error>
+            비밀번호는 8글자 이상에 숫자와 문자 각각 1글자 이상 포함해야 합니다.
+          </Error>
+        )}
+        <Label htmlFor="nickname">
+          <span>NICKNAME: </span>
+          <Input
+            id="nickname"
+            type="text"
+            value={nickname}
+            onChange={changeNicknameValue}
+          />
+        </Label>
+        {isNicknameErrorShown && (
+          <Error>닉네임은 2글자 이상이어야 합니다.</Error>
+        )}
+        <Button onClick={handleSubmit}>생성하기</Button>
+      </FormWrapper>
+    </>
+  );
+};
+
+export default SignupPage;

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -55,7 +55,9 @@ const SignupPage = () => {
         await submitSignupInfo(id, password, nickname);
         alert("생성되었습니다!");
         router.push(`/login`);
-      } catch {}
+      } catch {
+        // TODO: ID 중복 여부 검사, 부적절한 닉네임 여부 검사
+      }
     } else {
       setIsIdErrorShown(!isIdValid);
       setIsPasswordErrorShown(!isPasswordValid);

--- a/src/utils/checkPassword.ts
+++ b/src/utils/checkPassword.ts
@@ -1,0 +1,7 @@
+export const checkPassword = (inputText: string) => {
+  // 최소 8글자 이상, 영어 1글자와 숫자 1글자 포함
+  const validPassword = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+  if (inputText.match(validPassword)) {
+    return true;
+  } else return false;
+};

--- a/styles/commonStyles.ts
+++ b/styles/commonStyles.ts
@@ -1,0 +1,92 @@
+import styled from "styled-components";
+import { theme } from "./theme";
+
+export const Wrapper = styled.section`
+  display: flex;
+  justify-content: center;
+  flex-direction: row;
+  align-items: center;
+`;
+
+export const FormWrapper = styled.section`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  margin-top: 3rem;
+`;
+
+export const Error = styled.div`
+  color: #e01e5a;
+  margin: 0.5rem 0 1rem;
+  font-weight: bold;
+`;
+
+export const Title = styled.p`
+  font-weight: bold;
+  font-size: 2rem;
+`;
+
+export const Input = styled.input`
+  border-radius: 0.25rem;
+  --saf-0: rgba(var(--sk_foreground_high_solid, 134, 134, 134), 1);
+  border: 1px solid var(--saf-0);
+  transition: border 80ms ease-out, box-shadow 80ms ease-out;
+  box-sizing: border-box;
+  width: 100%;
+  color: rgba(var(--sk_primary_foreground, 29, 28, 29), 1);
+  background-color: rgba(var(--sk_primary_background, 255, 255, 255), 1);
+  padding: 0.75rem;
+  height: 2.75rem;
+  padding-top: 0.6875rem;
+  padding-bottom: 0.8125rem;
+  font-size: 1.125rem;
+  line-height: 1.33333333;
+  &:focus {
+    --saf-0: rgba(var(--sk_highlight, 18, 100, 163), 1);
+    box-shadow: 0 0 0 1px var(--saf-0), 0 0 0 5px rgba(29, 155, 209, 0.3);
+  }
+`;
+
+export const Label = styled.label`
+  margin-bottom: 1rem;
+  & > span {
+    display: block;
+    text-align: left;
+    padding-bottom: 0.5rem;
+    font-size: 0.9375rem;
+    cursor: pointer;
+    line-height: 1.46666667;
+    font-weight: 700;
+  }
+`;
+
+export const Button = styled.button`
+  margin-bottom: 0.75rem;
+  width: 5rem;
+  max-width: 100%;
+  color: #fff;
+  background-color: ${theme.buttonColor};
+  border: none;
+  font-size: 1.125rem;
+  font-weight: 900;
+  height: 2.75rem;
+  min-width: 6rem;
+  padding: 0 1rem 0.1875rem;
+  transition: all 80ms linear;
+  user-select: none;
+  outline: none;
+  cursor: pointer;
+  border-radius: 0.25rem;
+  box-shadow: 0 1px 0.25rem rgba(0, 0, 0, 0.3);
+  &:hover {
+    background-color: rgba(74, 21, 75, 0.9);
+    border: none;
+  }
+  &:focus {
+    --saf-0: rgba(var(--sk_highlight, 18, 100, 163), 1);
+    box-shadow: 0 0 0 1px var(--saf-0), 0 0 0 5px rgba(29, 155, 209, 0.3);
+  }
+  &:disabled {
+    background-color: ${theme.disabledButton};
+  }
+`;

--- a/type/User.ts
+++ b/type/User.ts
@@ -2,6 +2,7 @@ export type User = {
   id: string;
   nickname: string;
   password: string;
+  image?: string;
 };
 
 export type LoginInfoType = Omit<User, "nickname">;


### PR DESCRIPTION
1. 회원가입 페이지 마크업
2. `checkPassword` 유틸 구현
  - 정규표현식을 사용해서 비밀번호 input값의 길이가 8 이상이면서 동시에 문자와 숫자를 각각 1글자 이상 넣었는지 여부를 boolean 값으로 리턴. 생성하기 버튼을 눌렀을 때 validation을 진행하며 그에 따라 조건을 충족하지 않은 input에 대해 에러메시지 출력
3. API통신 구현(아직 API가 나오지 않았으므로 임시로 구현함, 로그인 POST API와 동일한 로직)
4. `pages/login/index.tsx`에서 사용되던 styled-components를 `commonStyles.ts`로 export함 -> signup 페이지에서 그대로 사용. 해당 부분 변경에 따른 `pages/login/index.tsx` 코드 수정은 #14 

![Jul-12-2022 23-03-40](https://user-images.githubusercontent.com/61453718/178509766-8479706f-166c-4d25-9aac-ce27762f3774.gif)
